### PR TITLE
Grasshopper Param

### DIFF
--- a/Plankton/PlanktonMesh.cs
+++ b/Plankton/PlanktonMesh.cs
@@ -18,6 +18,32 @@ namespace Plankton
         public PlanktonMesh() //blank constructor
         {
         }
+        
+        public PlanktonMesh(PlanktonMesh source)
+        {
+            foreach (var v in source.Vertices)
+            {
+                this.Vertices.Add(new PlanktonVertex() {
+                                      OutgoingHalfedge = v.OutgoingHalfedge,
+                                      X = v.X,
+                                      Y = v.Y,
+                                      Z = v.Z
+                                  });
+            }
+            foreach (var f in source.Faces)
+            {
+                this.Faces.Add(new PlanktonFace() { FirstHalfedge = f.FirstHalfedge });
+            }
+            foreach (var h in source.Halfedges)
+            {
+                this.Halfedges.Add(new PlanktonHalfedge() {
+                                       StartVertex = h.StartVertex,
+                                       AdjacentFace = h.AdjacentFace,
+                                       NextHalfedge = h.NextHalfedge,
+                                       PrevHalfedge = h.PrevHalfedge,
+                                   });
+            }
+        }
         #endregion
 
         #region "properties"

--- a/PlanktonGh/DecomposePlankton.cs
+++ b/PlanktonGh/DecomposePlankton.cs
@@ -24,7 +24,7 @@ namespace PlanktonGh
         /// </summary>
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddGenericParameter("PMesh", "PMesh", "The input PlanktonMesh to decompose", GH_ParamAccess.item);
+            pManager.AddParameter(new GH_PlanktonMeshParam(), "PMesh", "PMesh", "The input PlanktonMesh to decompose", GH_ParamAccess.item);
         }
 
         /// <summary>
@@ -48,8 +48,8 @@ namespace PlanktonGh
         /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            PlanktonMesh P = new PlanktonMesh();
-            if (!DA.GetData<PlanktonMesh>(0, ref P)) return;
+            PlanktonMesh P = null;
+            if (!DA.GetData(0, ref P)) return;
 
             List<Point3d> Positions = new List<Point3d>();
             List<int> OutHEdge = new List<int>();

--- a/PlanktonGh/GHMeshToPMesh_OBSOLETE.cs
+++ b/PlanktonGh/GHMeshToPMesh_OBSOLETE.cs
@@ -24,6 +24,11 @@ namespace PlanktonGh
                 "Mesh", "Triangulation")
         {
         }
+        
+        public override GH_Exposure Exposure
+        {
+            get { return GH_Exposure.hidden; }
+        }
 
         /// <summary>
         /// Registers all the input parameters for this component.

--- a/PlanktonGh/GH_PlanktonMesh.cs
+++ b/PlanktonGh/GH_PlanktonMesh.cs
@@ -1,0 +1,364 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Plankton;
+
+namespace PlanktonGh
+{
+    public class GH_PlanktonMesh : GH_GeometricGoo<PlanktonMesh>,
+        IGH_BakeAwareData, IGH_PreviewData, IGH_PreviewMeshData
+    {
+        Guid reference;
+        BoundingBox _b = BoundingBox.Unset;
+        Polyline[] _polylines;
+        Mesh _mesh;
+
+        public GH_PlanktonMesh() : this(null)
+        {
+        }
+
+        public GH_PlanktonMesh(PlanktonMesh mesh)
+        {
+            m_value = mesh;
+
+            ClearCaches();
+        }
+
+        public override PlanktonMesh Value
+        {
+            get
+            {
+                return base.Value;
+            }
+            set
+            {
+                base.Value = value;
+                ClearCaches();
+            }
+        }
+
+        public override Guid ReferenceID
+        {
+            get
+            {
+                return reference;
+            }
+            set
+            {
+                reference = value;
+            }
+        }
+
+        public override Rhino.Geometry.BoundingBox Boundingbox
+        {
+            get
+            {
+                if (m_value != null && !_b.IsValid)
+                {
+                    _b = new BoundingBox(m_value.Vertices.Select(v => v.ToPoint3d()));
+                }
+                return _b;
+            }
+        }
+
+        public override IGH_GeometricGoo DuplicateGeometry()
+        {
+            if(m_value == null) return null;
+
+            return new GH_PlanktonMesh(m_value == null ? null : new PlanktonMesh(m_value)) { ReferenceID = ReferenceID };
+        }
+
+        public override Rhino.Geometry.BoundingBox GetBoundingBox(Rhino.Geometry.Transform xform)
+        {
+            var b = Boundingbox;
+            b.Transform(xform);
+            return b;
+        }
+
+        public override IGH_GeometricGoo Morph(Rhino.Geometry.SpaceMorph xmorph)
+        {
+            if (m_value != null)
+            {
+                var m = new PlanktonMesh(m_value);
+
+                foreach (var v in m.Vertices)
+                {
+                    Point3d p = new Point3d(v.X, v.Y, v.Z);
+                    p = xmorph.MorphPoint(p);
+
+                    v.X = (float)p.X;
+                    v.Y = (float)p.Y;
+                    v.Z = (float)p.Z;
+                }
+
+                return new GH_PlanktonMesh(m);
+            }
+            else
+                return new GH_PlanktonMesh(null);
+        }
+
+        public override IGH_GeometricGoo Transform(Rhino.Geometry.Transform xform)
+        {
+            if (m_value != null)
+            {
+                var m = new PlanktonMesh(m_value);
+
+                foreach (var v in m.Vertices)
+                {
+                    Point3f p = new Point3f(v.X, v.Y, v.Z);
+                    p.Transform(xform);
+
+                    v.X = p.X;
+                    v.Y = p.Y;
+                    v.Z = p.Z;
+                }
+
+                return new GH_PlanktonMesh(m);
+            }
+            else
+                return new GH_PlanktonMesh(null);
+        }
+
+        public override string ToString()
+        {
+            if (m_value == null)
+                return "<Null mesh>";
+            else return m_value.ToString();
+        }
+
+        public override string TypeDescription
+        {
+            get { return "N-gonal Halfedge Mesh provided by Plankton"; }
+        }
+
+        public override string TypeName
+        {
+            get { return "PlanktonMesh"; }
+        }
+
+        public bool BakeGeometry(Rhino.RhinoDoc doc, Rhino.DocObjects.ObjectAttributes att, out Guid obj_guid)
+        {
+            if (_polylines == null)
+                ClearCaches();
+
+            obj_guid = Guid.Empty;
+
+            if (_polylines == null) return false;
+
+            for (int i = 0; i < _polylines.Length; i++)
+                doc.Objects.AddPolyline(_polylines[i]);
+
+            return true;
+        }
+
+
+
+        #region IGH_PreviewData Members
+
+        public BoundingBox ClippingBox
+        {
+            get { return Boundingbox; }
+        }
+
+        public void DrawViewportMeshes(GH_PreviewMeshArgs args)
+        {
+            if (this.m_value == null || _polylines == null)
+                return;
+
+            if (args.Pipeline.SupportsShading)
+            {
+                var c = args.Material.Diffuse;
+                c = System.Drawing.Color.FromArgb((int)(args.Material.Transparency * 255),
+                    c);
+
+                args.Pipeline.DrawMeshShaded(_mesh, args.Material);
+            }
+        }
+
+        public void DrawViewportWires(GH_PreviewWireArgs args)
+        {
+            if (this.m_value == null || _polylines == null)
+                return;
+
+            for (int i = 0; i < _polylines.Length; i++)
+                args.Pipeline.DrawPolygon(_polylines[i], args.Color, false);
+        }
+
+        #endregion
+
+        #region IGH_PreviewMeshData Members
+
+        public void DestroyPreviewMeshes()
+        {
+            m_value = null;
+        }
+
+        public Mesh[] GetPreviewMeshes()
+        {
+            if (m_value == null)
+            {
+                _mesh = null;
+                return null;
+            }
+
+            if (_mesh == null) _mesh = RhinoSupport.ToRhinoMesh(m_value);
+
+            return new Mesh[]
+            {
+                _mesh,
+            };
+        }
+
+        #endregion
+
+        public override bool LoadGeometry(Rhino.RhinoDoc doc)
+        {
+            RhinoObject obj = doc.Objects.Find(ReferenceID);
+            if (obj == null)
+            {
+                return false;
+            }
+            //if (obj.Geometry.ObjectType == ObjectType.Curve)
+            //{
+            //    var c = (Curve)obj.Geometry;
+            //
+            //    m_value = RhinoMeshSupport.ExtractTMesh(c);
+            //    ClearCaches();
+            //    return true;
+            //}
+            if (obj.Geometry.ObjectType == ObjectType.Mesh)
+            {
+                var m = (Mesh)obj.Geometry;
+
+                m_value = RhinoSupport.ToPlanktonMesh(m);
+                ClearCaches();
+                return true;
+            }
+            return false;
+        }
+
+        public override void ClearCaches()
+        {
+            //base.ClearCaches();
+
+            if (m_value == null)
+            {
+                _polylines = null;
+                _b = BoundingBox.Empty;
+                _mesh = null;
+            }
+            else
+            {
+                _polylines = RhinoSupport.ToPolylines(m_value);
+
+                _mesh = RhinoSupport.ToRhinoMesh(m_value);
+            }
+        }
+
+        //public override IGH_GooProxy EmitProxy()
+        //{
+        //    return new GH_PlanktonMeshProxy(this);
+        //}
+
+        public override bool CastFrom(object source)
+        {
+            if(source == null)
+            {
+                m_value = null;
+                ClearCaches();
+                return true;
+            }
+
+            if (source is GH_GeometricGoo<Mesh>)
+            {
+                source = ((GH_GeometricGoo<Mesh>)source).Value;
+            }
+            else if (source is GH_GeometricGoo<Curve>)
+            {
+                source = ((GH_GeometricGoo<Curve>)source).Value;
+            }
+
+            if (source is PlanktonMesh)
+            {
+                m_value = source as PlanktonMesh;
+                ClearCaches();
+                return true;
+            }
+            else if (source is Mesh)
+            {
+                m_value = RhinoSupport.ToPlanktonMesh((Mesh)source);
+                ClearCaches();
+                return true;
+            }
+            //else if (source is Curve)
+            //{
+            //    m_value = RhinoMeshSupport.ExtractTMesh((Curve)source);
+            //    ClearCaches();
+            //    return true;
+            //}
+            //else if (source is Grasshopper.Kernel.Types.GH_Curve)
+            //{
+            //    m_value = RhinoMeshSupport.ExtractTMesh((Curve)source);
+            //    ClearCaches();
+            //    return true;
+            //}
+
+            return base.CastFrom(source);
+        }
+
+        public override bool CastTo<Q>(out Q target)
+        {
+            if (typeof(Q) == typeof(Mesh) || typeof(Q) == typeof(GeometryBase))
+            {
+                target = (Q)(object)RhinoSupport.ToRhinoMesh(m_value);
+                return true;
+            }
+            if (typeof(Q) == (typeof(GH_Mesh)))
+            {
+                target = (Q)(object)new GH_Mesh(RhinoSupport.ToRhinoMesh(m_value));
+                return true;
+            }
+            if (typeof(Q) == typeof(PlanktonMesh))
+            {
+                target = (Q)(object)m_value;
+                return true;
+            }
+
+            return base.CastTo<Q>(out target);
+        }
+
+        //public override bool Read(GH_IO.Serialization.GH_IReader reader)
+        //{
+        //    var b = base.Read(reader);
+        //
+        //    var t = reader.GetString("PlanktonMesh");
+        //    m_value = Turtle.Serialization.Persistance.Read(new StringReader(t));
+        //
+        //    return b;
+        //}
+
+        //public override bool Write(GH_IO.Serialization.GH_IWriter writer)
+        //{
+        //    if(m_value != null)
+        //    {
+        //        StringWriter sw = new StringWriter();
+        //        Turtle.Serialization.Persistance.Write(m_value, sw);
+        //        sw.Flush();
+        //        var t = sw.ToString();
+        //
+        //        writer.SetString("PlanktonMesh", t);
+        //    }
+        //
+        //    return base.Write(writer);
+        //}
+
+        public override object ScriptVariable()
+        {
+            return Value;
+        }
+    }
+}

--- a/PlanktonGh/GH_PlanktonMeshParam.cs
+++ b/PlanktonGh/GH_PlanktonMeshParam.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using Grasshopper;
+using Grasshopper.Kernel;
+using Rhino.Geometry;
+using Rhino.Input.Custom;
+using PlanktonGh.Properties;
+
+namespace PlanktonGh
+{
+    public class GH_PlanktonMeshParam : GH_PersistentGeometryParam<GH_PlanktonMesh>, IGH_PreviewObject, IGH_BakeAwareObject
+    {
+        public GH_PlanktonMeshParam()
+            : base(new GH_InstanceDescription("PlanktonMesh", "PMesh", "Represents a list of 3D ngonal halfedge meshes", "Params", "Geometry"))
+        { }
+
+        protected override GH_PlanktonMesh InstantiateT()
+        {
+            return new GH_PlanktonMesh(null);
+        }
+
+        protected override GH_GetterResult Prompt_Plural(ref List<GH_PlanktonMesh> values)
+        {
+            GetObject go = new SpecialPolygonsGetObject();
+            go.GeometryFilter = Rhino.DocObjects.ObjectType.Mesh;
+            //go.GeometryAttributeFilter = GeometryAttributeFilter.ClosedMesh;
+
+            if (go.GetMultiple(1, 0) != Rhino.Input.GetResult.Object)
+                return GH_GetterResult.cancel;
+
+            if (values == null) values = new List<GH_PlanktonMesh>();
+            
+            for (int i=0; i<go.ObjectCount; i++)
+              values.Add(HandleOne(go, i));
+
+            return GH_GetterResult.success;
+        }
+
+        class SpecialPolygonsGetObject : GetObject
+        {
+            public override bool CustomGeometryFilter(
+                Rhino.DocObjects.RhinoObject rhObject,
+                Rhino.Geometry.GeometryBase geometry,
+                Rhino.Geometry.ComponentIndex componentIndex)
+            {
+                var m = geometry as Mesh;
+                if (m == null) return false;
+
+                return m.IsValid;
+            }
+        }
+
+        protected override GH_GetterResult Prompt_Singular(ref GH_PlanktonMesh value)
+        {
+            GetObject go = new SpecialPolygonsGetObject();
+            go.GeometryFilter = Rhino.DocObjects.ObjectType.Mesh;
+            //go.GeometryAttributeFilter = GeometryAttributeFilter.ClosedMesh;
+            
+            if (go.Get() != Rhino.Input.GetResult.Object)
+                return GH_GetterResult.cancel;
+
+            var m = HandleOne(go, 0);
+            
+            value = m;
+
+            return GH_GetterResult.success;
+        }
+
+        private static GH_PlanktonMesh HandleOne(GetObject go, int index)
+        {
+            var o = go.Object(index);
+            var m = o.Mesh();
+
+            var p = RhinoSupport.ToPlanktonMesh(m);
+
+            return new GH_PlanktonMesh(p) { ReferenceID = o.ObjectId };
+        }
+
+        public override Guid ComponentGuid
+        {
+            get { return new Guid("a484c1c6-bb88-4507-b650-58aadebda4c1"); }
+        }
+
+        public BoundingBox ClippingBox
+        {
+            get { return Preview_ComputeClippingBox(); }
+        }
+
+        public void DrawViewportMeshes(IGH_PreviewArgs args)
+        {
+            if (args.Document.PreviewMode == GH_PreviewMode.Shaded &&
+                args.Display.SupportsShading)
+            {
+                Preview_DrawMeshes(args);
+            }
+        }
+
+        public void DrawViewportWires(IGH_PreviewArgs args)
+        {
+            switch (args.Document.PreviewMode)
+            {
+                case GH_PreviewMode.Wireframe:
+                    Preview_DrawWires(args);
+                    break;
+                case GH_PreviewMode.Shaded:
+                    if (CentralSettings.PreviewMeshEdges)
+                    {
+                        Preview_DrawWires(args);
+                    }
+                    break;
+            }
+        }
+
+        bool _hidden;
+        public bool Hidden
+        {
+            get
+            {
+                return _hidden;
+            }
+            set
+            {
+                _hidden = value;
+            }
+        }
+
+        public bool IsPreviewCapable
+        {
+            get { return true; }
+        }
+
+        public void BakeGeometry(Rhino.RhinoDoc doc, Rhino.DocObjects.ObjectAttributes att, List<Guid> obj_ids)
+        {
+            if (att == null)
+            {
+                att = doc.CreateDefaultAttributes();
+            }
+            foreach (IGH_BakeAwareData item in m_data)
+            {
+                if (item != null)
+                {
+                    Guid id;
+                    if (item.BakeGeometry(doc, att, out id))
+                    {
+                        obj_ids.Add(id);
+                    }
+                }
+            }
+        }
+
+        public void BakeGeometry(Rhino.RhinoDoc doc, List<Guid> obj_ids)
+        {
+            BakeGeometry(doc, null, obj_ids);
+        }
+
+        public bool IsBakeCapable
+        {
+            get { return !m_data.IsEmpty; }
+        }
+
+        public override GH_Exposure Exposure
+        {
+            get
+            {
+                return GH_Exposure.tertiary;
+            }
+        }
+
+        protected override System.Drawing.Bitmap Icon
+        {
+            get
+            {
+                return Resources.plankton;
+            }
+        }
+    }
+}

--- a/PlanktonGh/PlanktonGh.csproj
+++ b/PlanktonGh/PlanktonGh.csproj
@@ -55,6 +55,8 @@
   <ItemGroup>
     <Compile Include="DecomposePlankton.cs" />
     <Compile Include="GHMeshToPMesh.cs" />
+    <Compile Include="GH_PlanktonMesh.cs" />
+    <Compile Include="GH_PlanktonMeshParam.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Some stuff I did at the weekend...

I basically just copied the _data type_ and _param_ implementation from Turtle. We need to decide whether this is okay to do and if so how to properly acknowledge the work done by Giulio Piacentino.

Note that I didn't make a ["proxy"](https://github.com/piac/TurtleMesh/blob/master/TurtleGh/GH_TurtleMeshProxy.cs) for Plankton, because I don't know what it is or why you need one!

Also, serialisation isn't implemented yet. Turtle handles the internalisation of ngon meshes just fine, so it's not something worth worrying about yet.

**Anyway...** the upshot of this is that Plankton's mesh feels much more native. It can exist as a _floating parameter_ (new icon needed) and can automatically cast from a Rhino mesh. For instance, try plugging a Rhino mesh _directly_ into the "DecomposePlankton" component.
